### PR TITLE
Add lyrics events

### DIFF
--- a/pretty_midi/containers.py
+++ b/pretty_midi/containers.py
@@ -188,3 +188,25 @@ class KeySignature(object):
     def __str__(self):
         return '{} at {:.2f} seconds'.format(
             key_number_to_key_name(self.key_number), self.time)
+
+
+class Lyric(object):
+    """Timestamped lyric text.
+
+    Attributes
+    ----------
+    text : str
+        The text of the lyric.
+    time : float
+        The time in seconds of the lyric.
+    """
+    def __init__(self, text, time):
+        self.text = text
+        self.time = time
+
+    def __repr__(self):
+        return 'Lyric(text="{}", time={})'.format(
+            self.text.replace('"', r'\"'), self.time)
+
+    def __str__(self):
+        return '"{}" at {:.2f} seconds'.format(self.text, self.time)


### PR DESCRIPTION
Resolves #72.

- Added `Lyric` container class
- Initialized empty `self.lyrics` list in `PrettyMIDI` constructor with no filename argument
- Loaded Lyrics events in `PrettyMIDI` constructor via load_meta
- Added adjustment of lyrics times in `adjust_times`
- Added write-out of lyrics events in `write`