### PR TITLE
Raise when requiring IOIs with too few notes

### DIFF
--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -461,7 +461,11 @@ class PrettyMIDI(object):
             Estimated tempo, in bpm
 
         """
-        return self.estimate_tempi()[0][0]
+        tempi = self.estimate_tempi()[0]
+        if tempi.size == 0:
+            raise ValueError("Can't provide a global tempo estimate when there"
+                             " are fewer than two notes.")
+        return tempi[0][0]
 
     def get_beats(self, start_time=0.):
         """Return a list of beat locations, according to MIDI tempo changes.
@@ -592,6 +596,9 @@ class PrettyMIDI(object):
         """
         # Get a sorted list of all notes from all instruments
         note_list = [n for i in self.instruments for n in i.notes]
+        if not note_list:
+            raise ValueError(
+                "Can't estimate beat start when there are no notes.")
         note_list.sort(key=lambda note: note.start)
         # List of possible beat trackings
         beat_candidates = []


### PR DESCRIPTION
Resolves #36.

When estimating a single global tempo, there needs to be at least two
notes so that at least one inner-onset-interval can be computed.  This
raises a `ValueError` whenever `estimate_tempo` is called when there are
fewer than two notes.  Also, in order to estimate the beat start, there
needs to be at least one note, so we raise a `ValueError` there too.  We
don't need to raise a `ValueError` in `estimate_tempo` because it just
returns empty `np.ndarray`s.