### PR TITLE
Python 3 compatibility fix

### DIFF
--- a/pretty_midi/utilities.py
+++ b/pretty_midi/utilities.py
@@ -142,7 +142,7 @@ def mode_accidentals_to_key_number(mode, num_accidentals):
     # check if key signature has sharps or flats
     if num_accidentals >= 0:
         num_sharps = num_accidentals / 6
-        key = sharp_keys[num_accidentals % 7] + '#' * num_sharps
+        key = sharp_keys[num_accidentals % 7] + '#' * int(num_sharps)
     else:
         if num_accidentals == -1:
             key = 'F'


### PR DESCRIPTION
`[] * x` causes a TypeError in Python 3 when `x` is interpreted as a float. Enforcing it to be an int.

```sh
Traceback (most recent call last):
  File "test.py", line 56, in <module>
    pm = pretty_midi.PrettyMIDI(midi_path)
  File "/home/carl/anaconda3/lib/python3.5/site-packages/pretty_midi/pretty_midi.py", line 75, in __init__
    self._load_metadata(midi_data)
  File "/home/carl/anaconda3/lib/python3.5/site-packages/pretty_midi/pretty_midi.py", line 164, in _load_metadata
    event.data[1], event.get_alternatives()),
  File "/home/carl/anaconda3/lib/python3.5/site-packages/pretty_midi/utilities.py", line 145, in mode_accidentals_to_key_number
    key = sharp_keys[num_accidentals % 7] + '#' * num_sharps
TypeError: can't multiply sequence by non-int of type 'float'
```