### PR TITLE
Give GitHub link for midi package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,6 @@ setup(
         'numpy >= 1.7.0',
         'midi'
     ],
+    dependency_links=[
+        'https://github.com/vishnubob/python-midi/tarball/master#egg=midi']
 )


### PR DESCRIPTION
Due to issues with installing midi from pip (see #92), this should explicitly make pip install the bleeding-edge.  @cghawthorne can you confirm this fixes the problem you were facing?