### PR TITLE
Supply explicit version for midi dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,9 @@ setup(
     license='MIT',
     install_requires=[
         'numpy >= 1.7.0',
-        'midi'
+        'midi ==v0.2.3'
     ],
     dependency_links=[
-        'https://github.com/vishnubob/python-midi/tarball/master#egg=midi']
+        ('https://github.com/vishnubob/python-midi/tarball/'
+         'master#egg=midi-v0.2.3')]
 )


### PR DESCRIPTION
This is the version ('v0.2.3', not '0.2.3', or even '0.2.4', the latest version on PyPI) specified in the bleeding-edge setup.py in GitHub.  This (specifying a version) actually forces python setup.py install to  use GitHub.

@cghawthorne does this fix it for you?