### PR TITLE
Remove ur prefix from key regexp string

### DIFF
--- a/pretty_midi/utilities.py
+++ b/pretty_midi/utilities.py
@@ -81,7 +81,7 @@ def key_name_to_key_number(key_string):
     # Construct regular expression for matching key
     pattern = re.compile(
         # Start with any of A-G, a-g
-        ur'^(?P<key>[ABCDEFGabcdefg])'
+        '^(?P<key>[ABCDEFGabcdefg])'
         # Next, look for #, b, or nothing
         '(?P<flatsharp>[#b]?)'
         # Allow for a space between key and mode


### PR DESCRIPTION
The ur prefix is not supported in Python 3.  The string itself actually did not require this prefix as there weren't any unicode characters or characters requiring escaping.  Resolves #104.