### PR TITLE
#131 fix swapped note-on note-off events

### DIFF
--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -335,7 +335,8 @@ class PrettyMIDI(object):
                             start_time = self.__tick_to_time[start_tick]
                             end_time = self.__tick_to_time[end_tick]
                             # Create the note event
-                            note = Note(velocity, event.note, start_time, end_time)
+                            note = Note(velocity, event.note, start_time,
+                                        end_time)
                             # Get the program and drum type for the current
                             # instrument
                             program = current_instrument[event.channel]

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -274,6 +274,7 @@ def test_adjust_times():
         assert ks.time == t
         assert ks.key_number == k
 
+
 def test_properly_order_overlapping_notes():
     def make_mido_track(notes_str, path):
         track = mido.MidiTrack()
@@ -316,7 +317,8 @@ def test_properly_order_overlapping_notes():
         pm_song = pretty_midi.PrettyMIDI(midi_path)
 
         def extract_notes(pm_track):
-            return np.array([(note.pitch, note.end-note.start) for note in pm_track.notes])
+            return np.array([(note.pitch, note.end-note.start) for note
+                             in pm_track.notes])
 
         expected = np.array([[72, 0.05], [72, 0.05], [74, 0.05], [72, 0.05]])
         assert np.allclose(expected, extract_notes(pm_song.instruments[0]))
@@ -325,4 +327,5 @@ def test_properly_order_overlapping_notes():
         pm_song.write(midi_written_path)
         pm_song_written = pretty_midi.PrettyMIDI(midi_written_path)
 
-        assert np.allclose(expected, extract_notes(pm_song_written.instruments[0]))
+        assert np.allclose(expected,
+                           extract_notes(pm_song_written.instruments[0]))


### PR DESCRIPTION
This fixes the issue #131 (and helps to solve #52). Basically in case there are adjacent notes in the MIDI but at the same tick the note-on precedes note-off it's meaning was to close the previous note and open new note. The library however closed all open notes, including this. It created an empty event and sometimes long running notes that were closed only after encountering a matching note-off.

The solution was to keep the note-on event if it's at the same tick and we already closed some events.

I created a minimal test covering both cases - correct and swapped order. The input MIDI is produces via `mido`. We test both reading and writing.

Test are green and on real data piano rolls it seems the bug is fixed.