### PR TITLE
Added support for elongating note when encountering CC64

### DIFF
--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -739,7 +739,7 @@ class PrettyMIDI(object):
         # Return them sorted (because why not?)
         return np.sort(onsets)
 
-    def get_piano_roll(self, fs=100, times=None):
+    def get_piano_roll(self, fs=100, times=None, sustain_pedal_elongates_note=False, sustain_pedal_elongate_thres=64):
         """Compute a piano roll matrix of the MIDI data.
 
         Parameters
@@ -750,6 +750,13 @@ class PrettyMIDI(object):
         times : np.ndarray
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
+        sustain_pedal_elongates_note : Boolean
+            Control Change 64 (Sustain pedal) is reflected as elongation of notes.
+            Default is False, which does nothing.  If True, then CC64 value greater
+            than sustain_pedal_elongate_thres will be treated as pedal on and rest as pedal off.
+        sustain_pedal_elongate_thres : Int
+            The threshold value for treating CC64 message as elongation of note.
+            Default is ``64``
 
         Returns
         -------
@@ -763,7 +770,9 @@ class PrettyMIDI(object):
             return np.zeros((128, 0))
 
         # Get piano rolls for each instrument
-        piano_rolls = [i.get_piano_roll(fs=fs, times=times)
+        piano_rolls = [i.get_piano_roll(fs=fs, times=times,
+                                        sustain_pedal_elongates_note=sustain_pedal_elongates_note,
+                                        sustain_pedal_elongate_thres=sustain_pedal_elongate_thres)
                        for i in self.instruments]
         # Allocate piano roll,
         # number of columns is max of # of columns in all piano rolls


### PR DESCRIPTION
I addressed issue #130 , and added a functionality to take into account sustain pedals, when extracting the pianoroll