### PR TITLE
Add support for sustain pedal (pianoroll and chromagram)

### DIFF
--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -74,8 +74,7 @@ class Instrument(object):
         return np.sort(onsets)
 
     def get_piano_roll(self, fs=100, times=None,
-                       use_pedal=False,
-                       pedal_threshold=64):
+                       pedal_threshold=None):
         """Compute a piano roll matrix of this instrument.
 
         Parameters
@@ -86,16 +85,11 @@ class Instrument(object):
         times : np.ndarray
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
-        use_pedal : Boolean
-            Control Change 64 (Sustain pedal) is reflected as elongation of
-            notes.
-            Default is False, which does nothing.  If True, then CC64 value
-            greater than pedal_threshold will be treated as pedal on and
-            the rest as pedal off.
-        pedal_threshold : Int
-            The threshold value for treating CC64 message as elongation of a
-            note.
-            Default is ``64``
+        pedal_threshold : int
+            Value of control change 64 (sustain pedal) message that is above
+            this value is reflected as pedal-on.  Pedals will be reflected as
+            elongation of notes in the piano roll.
+            Default is None, which ignores CC64 messages.
 
         Returns
         -------
@@ -126,7 +120,7 @@ class Instrument(object):
                        int(note.start*fs):int(note.end*fs)] += note.velocity
 
         # Process sustain pedals
-        if use_pedal:
+        if pedal_threshold is not None:
             CC_SUSTAIN_PEDAL = 64
             time_pedal_on = 0
             is_pedal_on = False
@@ -198,8 +192,7 @@ class Instrument(object):
                                                   axis=1)
         return piano_roll_integrated
 
-    def get_chroma(self, fs=100, times=None, use_pedal=False,
-                   pedal_threshold=64):
+    def get_chroma(self, fs=100, times=None, pedal_threshold=None):
         """Get a sequence of chroma vectors from this instrument.
 
         Parameters
@@ -210,16 +203,11 @@ class Instrument(object):
         times : np.ndarray
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
-        use_pedal : Boolean
-            Control Change 64 (Sustain pedal) is reflected as elongation of
-            notes.
-            Default is False, which does nothing.  If True, then CC64 value
-            greater than pedal_threshold will be treated as pedal on and
-            the rest as pedal off.
-        pedal_threshold : Int
-            The threshold value for treating CC64 message as elongation of a
-            note.
-            Default is ``64``
+        pedal_threshold : int
+            Value of control change 64 (sustain pedal) message that is above
+            this value is reflected as pedal-on.  Pedals will be reflected as
+            elongation of notes in the chromagram.
+            Default is None, which ignores CC64 messages.
 
         Returns
         -------
@@ -229,7 +217,6 @@ class Instrument(object):
         """
         # First, get the piano roll
         piano_roll = self.get_piano_roll(fs=fs, times=times,
-                                         use_pedal=use_pedal,
                                          pedal_threshold=pedal_threshold)
         # Fold into one octave
         chroma_matrix = np.zeros((12, piano_roll.shape[1]))

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -138,9 +138,13 @@ class Instrument(object):
                     time_pedal_on = time_now
                     is_pedal_on = True
                 elif is_pedal_on and not is_current_pedal_on:
+                    # For each pitch, a sustain pedal "retains"
+                    # the maximum velocity up to now due to
+                    # logarithmic nature of human loudness perception
                     subpr = piano_roll[:, time_pedal_on:time_now]
-                    pedaled = np.minimum(subpr.cumsum(1),
-                                         subpr.max(1)[:, np.newaxis])
+
+                    # Take the running maximum
+                    pedaled = np.maximum.accumulate(subpr, axis=1)
                     piano_roll[:, time_pedal_on:time_now] = pedaled
                     is_pedal_on = False
 

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -74,7 +74,7 @@ class Instrument(object):
         return np.sort(onsets)
 
     def get_piano_roll(self, fs=100, times=None,
-                       pedal_threshold=None):
+                       pedal_threshold=64):
         """Compute a piano roll matrix of this instrument.
 
         Parameters
@@ -89,7 +89,8 @@ class Instrument(object):
             Value of control change 64 (sustain pedal) message that is above
             this value is reflected as pedal-on.  Pedals will be reflected as
             elongation of notes in the piano roll.
-            Default is None, which ignores CC64 messages.
+            If None, then CC64 message is ignored.
+            Default is 64.
 
         Returns
         -------
@@ -192,7 +193,7 @@ class Instrument(object):
                                                   axis=1)
         return piano_roll_integrated
 
-    def get_chroma(self, fs=100, times=None, pedal_threshold=None):
+    def get_chroma(self, fs=100, times=None, pedal_threshold=64):
         """Get a sequence of chroma vectors from this instrument.
 
         Parameters
@@ -207,7 +208,8 @@ class Instrument(object):
             Value of control change 64 (sustain pedal) message that is above
             this value is reflected as pedal-on.  Pedals will be reflected as
             elongation of notes in the chromagram.
-            Default is None, which ignores CC64 messages.
+            If None, then CC64 message is ignored.
+            Default is 64.
 
         Returns
         -------

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -86,9 +86,9 @@ class Instrument(object):
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
         pedal_threshold : int
-            Value of control change 64 (sustain pedal) message that is above
-            this value is reflected as pedal-on.  Pedals will be reflected as
-            elongation of notes in the piano roll.
+            Value of control change 64 (sustain pedal) message that is less
+            than this value is reflected as pedal-off.  Pedals will be
+            reflected as elongation of notes in the piano roll.
             If None, then CC64 message is ignored.
             Default is 64.
 
@@ -128,7 +128,7 @@ class Instrument(object):
             for cc in [_e for _e in self.control_changes
                        if _e.number == CC_SUSTAIN_PEDAL]:
                 time_now = int(cc.time*fs)
-                is_current_pedal_on = (cc.value > pedal_threshold)
+                is_current_pedal_on = (cc.value >= pedal_threshold)
                 if not is_pedal_on and is_current_pedal_on:
                     time_pedal_on = time_now
                     is_pedal_on = True
@@ -205,9 +205,9 @@ class Instrument(object):
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
         pedal_threshold : int
-            Value of control change 64 (sustain pedal) message that is above
-            this value is reflected as pedal-on.  Pedals will be reflected as
-            elongation of notes in the chromagram.
+            Value of control change 64 (sustain pedal) message that is less
+            than this value is reflected as pedal-off.  Pedals will be
+            reflected as elongation of notes in the piano roll.
             If None, then CC64 message is ignored.
             Default is 64.
 

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -739,7 +739,7 @@ class PrettyMIDI(object):
         # Return them sorted (because why not?)
         return np.sort(onsets)
 
-    def get_piano_roll(self, fs=100, times=None, pedal_threshold=None):
+    def get_piano_roll(self, fs=100, times=None, pedal_threshold=64):
         """Compute a piano roll matrix of the MIDI data.
 
         Parameters
@@ -754,7 +754,8 @@ class PrettyMIDI(object):
             Value of control change 64 (sustain pedal) message that is above
             this value is reflected as pedal-on.  Pedals will be reflected as
             elongation of notes in the piano roll.
-            Default is None, which ignores CC64 messages.
+            If None, then CC64 message is ignored.
+            Default is 64.
 
         Returns
         -------
@@ -839,7 +840,7 @@ class PrettyMIDI(object):
 
         return pc_trans_mat
 
-    def get_chroma(self, fs=100, times=None, pedal_threshold=None):
+    def get_chroma(self, fs=100, times=None, pedal_threshold=64):
         """Get the MIDI data as a sequence of chroma vectors.
 
         Parameters
@@ -854,7 +855,8 @@ class PrettyMIDI(object):
             Value of control change 64 (sustain pedal) message that is above
             this value is reflected as pedal-on.  Pedals will be reflected as
             elongation of notes in the chromagram.
-            Default is None, which ignores CC64 messages.
+            If None, then CC64 message is ignored.
+            Default is 64.
 
         Returns
         -------

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -739,9 +739,7 @@ class PrettyMIDI(object):
         # Return them sorted (because why not?)
         return np.sort(onsets)
 
-    def get_piano_roll(self, fs=100, times=None,
-                       use_pedal=False,
-                       pedal_threshold=64):
+    def get_piano_roll(self, fs=100, times=None, pedal_threshold=None):
         """Compute a piano roll matrix of the MIDI data.
 
         Parameters
@@ -752,16 +750,11 @@ class PrettyMIDI(object):
         times : np.ndarray
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
-        use_pedal : Boolean
-            Control Change 64 (Sustain pedal) is reflected as elongation of
-            notes.
-            Default is False, which does nothing.  If True, then CC64 value
-            greater than pedal_threshold will be treated as pedal on and
-            the rest as pedal off.
-        pedal_threshold : Int
-            The threshold value for treating CC64 message as elongation of a
-            note.
-            Default is ``64``
+        pedal_threshold : int
+            Value of control change 64 (sustain pedal) message that is above
+            this value is reflected as pedal-on.  Pedals will be reflected as
+            elongation of notes in the piano roll.
+            Default is None, which ignores CC64 messages.
 
         Returns
         -------
@@ -776,7 +769,6 @@ class PrettyMIDI(object):
 
         # Get piano rolls for each instrument
         piano_rolls = [i.get_piano_roll(fs=fs, times=times,
-                                        use_pedal=use_pedal,
                                         pedal_threshold=pedal_threshold)
                        for i in self.instruments]
         # Allocate piano roll,
@@ -847,8 +839,7 @@ class PrettyMIDI(object):
 
         return pc_trans_mat
 
-    def get_chroma(self, fs=100, times=None, use_pedal=False,
-                   pedal_threshold=64):
+    def get_chroma(self, fs=100, times=None, pedal_threshold=None):
         """Get the MIDI data as a sequence of chroma vectors.
 
         Parameters
@@ -859,16 +850,11 @@ class PrettyMIDI(object):
         times : np.ndarray
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
-        use_pedal : Boolean
-            Control Change 64 (Sustain pedal) is reflected as elongation of
-            notes.
-            Default is False, which does nothing.  If True, then CC64 value
-            greater than pedal_threshold will be treated as pedal on and
-            the rest as pedal off.
-        pedal_threshold : Int
-            The threshold value for treating CC64 message as elongation of a
-            note.
-            Default is ``64``
+        pedal_threshold : int
+            Value of control change 64 (sustain pedal) message that is above
+            this value is reflected as pedal-on.  Pedals will be reflected as
+            elongation of notes in the chromagram.
+            Default is None, which ignores CC64 messages.
 
         Returns
         -------
@@ -878,7 +864,6 @@ class PrettyMIDI(object):
         """
         # First, get the piano roll
         piano_roll = self.get_piano_roll(fs=fs, times=times,
-                                         use_pedal=use_pedal,
                                          pedal_threshold=pedal_threshold)
         # Fold into one octave
         chroma_matrix = np.zeros((12, piano_roll.shape[1]))

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -751,9 +751,9 @@ class PrettyMIDI(object):
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
         pedal_threshold : int
-            Value of control change 64 (sustain pedal) message that is above
-            this value is reflected as pedal-on.  Pedals will be reflected as
-            elongation of notes in the piano roll.
+            Value of control change 64 (sustain pedal) message that is less
+            than this value is reflected as pedal-off.  Pedals will be
+            reflected as elongation of notes in the piano roll.
             If None, then CC64 message is ignored.
             Default is 64.
 
@@ -852,9 +852,9 @@ class PrettyMIDI(object):
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
         pedal_threshold : int
-            Value of control change 64 (sustain pedal) message that is above
-            this value is reflected as pedal-on.  Pedals will be reflected as
-            elongation of notes in the chromagram.
+            Value of control change 64 (sustain pedal) message that is less
+            than this value is reflected as pedal-off.  Pedals will be
+            reflected as elongation of notes in the piano roll.
             If None, then CC64 message is ignored.
             Default is 64.
 

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -739,7 +739,7 @@ class PrettyMIDI(object):
         # Return them sorted (because why not?)
         return np.sort(onsets)
 
-    def get_piano_roll(self, fs=100, times=None):
+    def get_piano_roll(self, fs=100, times=None, sustain_pedal_elongates_note=False, sustain_pedal_elongate_thres=64):
         """Compute a piano roll matrix of the MIDI data.
 
         Parameters
@@ -750,6 +750,13 @@ class PrettyMIDI(object):
         times : np.ndarray
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
+        sustain_pedal_elongates_note : Boolean
+            Control Change 64 (Sustain pedal) is reflected as elongation of notes.
+            Default is False, which does nothing.  If True, then CC64 value greater
+            than sustain_pedal_elongate_thres will be treated as pedal on and rest as pedal off.
+        sustain_pedal_elongate_thres : Int
+            The threshold value for treating CC64 message as elongation of note.
+            Default is ``64``
 
         Returns
         -------
@@ -763,7 +770,9 @@ class PrettyMIDI(object):
             return np.zeros((128, 0))
 
         # Get piano rolls for each instrument
-        piano_rolls = [i.get_piano_roll(fs=fs, times=times)
+        piano_rolls = [i.get_piano_roll(fs=fs, times=times,
+                                        sustain_pedal_elongates_note=sustain_pedal_elongates_note,
+                                        sustain_pedal_elongate_thres=sustain_pedal_elongate_thres)
                        for i in self.instruments]
         # Allocate piano roll,
         # number of columns is max of # of columns in all piano rolls

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -739,7 +739,9 @@ class PrettyMIDI(object):
         # Return them sorted (because why not?)
         return np.sort(onsets)
 
-    def get_piano_roll(self, fs=100, times=None, sustain_pedal_elongates_note=False, sustain_pedal_elongate_thres=64):
+    def get_piano_roll(self, fs=100, times=None,
+                       use_pedal=False,
+                       pedal_threshold=64):
         """Compute a piano roll matrix of the MIDI data.
 
         Parameters
@@ -750,12 +752,15 @@ class PrettyMIDI(object):
         times : np.ndarray
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
-        sustain_pedal_elongates_note : Boolean
-            Control Change 64 (Sustain pedal) is reflected as elongation of notes.
-            Default is False, which does nothing.  If True, then CC64 value greater
-            than sustain_pedal_elongate_thres will be treated as pedal on and rest as pedal off.
-        sustain_pedal_elongate_thres : Int
-            The threshold value for treating CC64 message as elongation of note.
+        use_pedal : Boolean
+            Control Change 64 (Sustain pedal) is reflected as elongation of
+            notes.
+            Default is False, which does nothing.  If True, then CC64 value
+            greater than pedal_threshold will be treated as pedal on and
+            the rest as pedal off.
+        pedal_threshold : Int
+            The threshold value for treating CC64 message as elongation of a
+            note.
             Default is ``64``
 
         Returns
@@ -771,8 +776,8 @@ class PrettyMIDI(object):
 
         # Get piano rolls for each instrument
         piano_rolls = [i.get_piano_roll(fs=fs, times=times,
-                                        sustain_pedal_elongates_note=sustain_pedal_elongates_note,
-                                        sustain_pedal_elongate_thres=sustain_pedal_elongate_thres)
+                                        use_pedal=use_pedal,
+                                        pedal_threshold=pedal_threshold)
                        for i in self.instruments]
         # Allocate piano roll,
         # number of columns is max of # of columns in all piano rolls
@@ -842,7 +847,8 @@ class PrettyMIDI(object):
 
         return pc_trans_mat
 
-    def get_chroma(self, fs=100, times=None):
+    def get_chroma(self, fs=100, times=None, use_pedal=False,
+                   pedal_threshold=64):
         """Get the MIDI data as a sequence of chroma vectors.
 
         Parameters
@@ -853,6 +859,16 @@ class PrettyMIDI(object):
         times : np.ndarray
             Times of the start of each column in the piano roll.
             Default ``None`` which is ``np.arange(0, get_end_time(), 1./fs)``.
+        use_pedal : Boolean
+            Control Change 64 (Sustain pedal) is reflected as elongation of
+            notes.
+            Default is False, which does nothing.  If True, then CC64 value
+            greater than pedal_threshold will be treated as pedal on and
+            the rest as pedal off.
+        pedal_threshold : Int
+            The threshold value for treating CC64 message as elongation of a
+            note.
+            Default is ``64``
 
         Returns
         -------
@@ -861,7 +877,9 @@ class PrettyMIDI(object):
 
         """
         # First, get the piano roll
-        piano_roll = self.get_piano_roll(fs=fs, times=times)
+        piano_roll = self.get_piano_roll(fs=fs, times=times,
+                                         use_pedal=use_pedal,
+                                         pedal_threshold=pedal_threshold)
         # Fold into one octave
         chroma_matrix = np.zeros((12, piano_roll.shape[1]))
         for note in range(12):

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -432,12 +432,13 @@ def test_get_piano_roll_and_get_chroma():
     expected_piano_roll[55, 10:15] = 20
     expected_piano_roll[55, 20:25] = 10
     expected_piano_roll[55, 30:42] = 50
-    assert np.allclose(pm.get_piano_roll(), expected_piano_roll)
+    assert np.allclose(pm.get_piano_roll(pedal_threshold=None),
+                       expected_piano_roll)
 
     expected_piano_roll[50, 35:50] = 50
     expected_piano_roll[55, 10:30] = 20
     expected_piano_roll[55, 30:50] = 50
-    assert np.allclose(pm.get_piano_roll(pedal_threshold=64),
+    assert np.allclose(pm.get_piano_roll(),
                        expected_piano_roll)
 
     expected_chroma = np.zeros((12, 50))
@@ -449,12 +450,13 @@ def test_get_piano_roll_and_get_chroma():
     expected_chroma[7, 10:15] = 20
     expected_chroma[7, 20:25] = 10
     expected_chroma[7, 30:42] = 50
-    assert np.allclose(pm.get_chroma(), expected_chroma)
+    assert np.allclose(pm.get_chroma(pedal_threshold=None),
+                       expected_chroma)
 
     expected_chroma[2, 35:50] = 50
     expected_chroma[7, 10:30] = 20
     expected_chroma[7, 30:50] = 50
-    assert np.allclose(pm.get_chroma(pedal_threshold=64),
+    assert np.allclose(pm.get_chroma(),
                        expected_chroma)
 
 

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -406,19 +406,44 @@ def test_get_piano_roll_and_get_chroma():
     inst.notes.append(pretty_midi.Note(pitch=45, velocity=100, start=0.1,
                                        end=0.2))
 
+    inst = pretty_midi.Instrument(0)
+    pm.instruments.append(inst)
+    inst.control_changes.append(pretty_midi.ControlChange(number=64,
+                                                          value=65,
+                                                          time=0.38))
+    inst.control_changes.append(pretty_midi.ControlChange(number=64,
+                                                          value=63,
+                                                          time=0.5))
+    inst.notes.append(pretty_midi.Note(pitch=50, velocity=50, start=0.35,
+                                       end=0.4))
+    inst.notes.append(pretty_midi.Note(pitch=55, velocity=100, start=0.1,
+                                       end=0.42))
+
     expected_piano_roll = np.zeros((128, 50))
     expected_piano_roll[40, 5:35] = 100
     expected_piano_roll[40, 35:45] = 150
     expected_piano_roll[40, 45:] = 50
     expected_piano_roll[45, 10:20] = 100
+    expected_piano_roll[50, 35:40] = 50
+    expected_piano_roll[55, 10:42] = 100
     assert np.allclose(pm.get_piano_roll(), expected_piano_roll)
+
+    expected_piano_roll[50, 35:50] = 50
+    expected_piano_roll[55, 10:50] = 100
+    assert np.allclose(pm.get_piano_roll(use_pedal=True), expected_piano_roll)
 
     expected_chroma = np.zeros((12, 50))
     expected_chroma[4, 5:35] = 100
     expected_chroma[4, 35:45] = 150
     expected_chroma[4, 45:] = 50
     expected_chroma[9, 10:20] = 100
+    expected_chroma[2, 35:40] = 50
+    expected_chroma[7, 10:42] = 100
     assert np.allclose(pm.get_chroma(), expected_chroma)
+
+    expected_chroma[2, 35:50] = 50
+    expected_chroma[7, 10:50] = 100
+    assert np.allclose(pm.get_chroma(use_pedal=True), expected_chroma)
 
 
 def test_synthesize():

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -437,7 +437,8 @@ def test_get_piano_roll_and_get_chroma():
     expected_piano_roll[50, 35:50] = 50
     expected_piano_roll[55, 10:30] = 20
     expected_piano_roll[55, 30:50] = 50
-    assert np.allclose(pm.get_piano_roll(pedal_threshold=64), expected_piano_roll)
+    assert np.allclose(pm.get_piano_roll(pedal_threshold=64),
+                       expected_piano_roll)
 
     expected_chroma = np.zeros((12, 50))
     expected_chroma[4, 5:35] = 100
@@ -453,7 +454,8 @@ def test_get_piano_roll_and_get_chroma():
     expected_chroma[2, 35:50] = 50
     expected_chroma[7, 10:30] = 20
     expected_chroma[7, 30:50] = 50
-    assert np.allclose(pm.get_chroma(pedal_threshold=64), expected_chroma)
+    assert np.allclose(pm.get_chroma(pedal_threshold=64),
+                       expected_chroma)
 
 
 def test_synthesize():

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -410,13 +410,17 @@ def test_get_piano_roll_and_get_chroma():
     pm.instruments.append(inst)
     inst.control_changes.append(pretty_midi.ControlChange(number=64,
                                                           value=65,
-                                                          time=0.38))
+                                                          time=0.12))
     inst.control_changes.append(pretty_midi.ControlChange(number=64,
                                                           value=63,
                                                           time=0.5))
     inst.notes.append(pretty_midi.Note(pitch=50, velocity=50, start=0.35,
                                        end=0.4))
-    inst.notes.append(pretty_midi.Note(pitch=55, velocity=100, start=0.1,
+    inst.notes.append(pretty_midi.Note(pitch=55, velocity=20, start=0.1,
+                                       end=0.15))
+    inst.notes.append(pretty_midi.Note(pitch=55, velocity=10, start=0.2,
+                                       end=0.25))
+    inst.notes.append(pretty_midi.Note(pitch=55, velocity=50, start=0.3,
                                        end=0.42))
 
     expected_piano_roll = np.zeros((128, 50))
@@ -425,12 +429,15 @@ def test_get_piano_roll_and_get_chroma():
     expected_piano_roll[40, 45:] = 50
     expected_piano_roll[45, 10:20] = 100
     expected_piano_roll[50, 35:40] = 50
-    expected_piano_roll[55, 10:42] = 100
+    expected_piano_roll[55, 10:15] = 20
+    expected_piano_roll[55, 20:25] = 10
+    expected_piano_roll[55, 30:42] = 50
     assert np.allclose(pm.get_piano_roll(), expected_piano_roll)
 
     expected_piano_roll[50, 35:50] = 50
-    expected_piano_roll[55, 10:50] = 100
-    assert np.allclose(pm.get_piano_roll(use_pedal=True), expected_piano_roll)
+    expected_piano_roll[55, 10:30] = 20
+    expected_piano_roll[55, 30:50] = 50
+    assert np.allclose(pm.get_piano_roll(pedal_threshold=64), expected_piano_roll)
 
     expected_chroma = np.zeros((12, 50))
     expected_chroma[4, 5:35] = 100
@@ -438,12 +445,15 @@ def test_get_piano_roll_and_get_chroma():
     expected_chroma[4, 45:] = 50
     expected_chroma[9, 10:20] = 100
     expected_chroma[2, 35:40] = 50
-    expected_chroma[7, 10:42] = 100
+    expected_chroma[7, 10:15] = 20
+    expected_chroma[7, 20:25] = 10
+    expected_chroma[7, 30:42] = 50
     assert np.allclose(pm.get_chroma(), expected_chroma)
 
     expected_chroma[2, 35:50] = 50
-    expected_chroma[7, 10:50] = 100
-    assert np.allclose(pm.get_chroma(use_pedal=True), expected_chroma)
+    expected_chroma[7, 10:30] = 20
+    expected_chroma[7, 30:50] = 50
+    assert np.allclose(pm.get_chroma(pedal_threshold=64), expected_chroma)
 
 
 def test_synthesize():


### PR DESCRIPTION
I addressed issue #130 , and added a functionality to take into account sustain pedals, when extracting the piano-roll and the chromagram.  