### PR TITLE
enforce strictly increasing values in old_time and new_time

### DIFF
--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -1019,6 +1019,20 @@ class PrettyMIDI(object):
         # Get original downbeat locations (we will use them to determine where
         # to put the first time signature change)
         original_downbeats = self.get_downbeats()
+        # Force strict increase in original_times and monotonic in new_times.
+        # While enforcing, give warning.
+        original_size = len(original_times)
+        original_times, unique_idx = np.unique(original_times,
+                                               return_index=True)
+        if ((unique_idx.size != original_size) or
+                any(unique_idx != np.arange(unique_idx.size))):
+            warnings.warn('original_times must be strictly increasing; '
+                          'automatically enforcing this.')
+        new_times = np.asarray(new_times)[unique_idx]
+        if not np.all(np.diff(new_times) >= 0):
+            warnings.warn('new_times must be monotonic; '
+                          'automatically enforcing this.')
+            new_times = np.maximum.accumulate(new_times)
         # Only include notes within start/end time of the provided times
         for instrument in self.instruments:
             instrument.notes = [copy.deepcopy(note)

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -162,9 +162,9 @@ def test_adjust_times():
     assert np.allclose(
         [n.start for n in pm.instruments[0].notes], expected_starts)
     pm = simple()
-    pm.adjust_times([0, 5, 5, 10], [5, 10, 12, 17])
+    pm.adjust_times([0, 5, 5, 10], [7, 12, 13, 17])
     # Original times  [1, 2, 3, 4,  5,  6,  7,  8,  9]
-    expected_starts = [6, 7, 8, 9, 12, 13, 14, 15, 16]
+    expected_starts = [8, 9, 10, 11, 12, 13, 14, 15, 16]
     assert np.allclose(
         [n.start for n in pm.instruments[0].notes], expected_starts)
 
@@ -233,11 +233,9 @@ def test_adjust_times():
     assert np.allclose(expected_tempi, tempi, rtol=.002)
 
     # Test that all other events were interpolated as expected
-    note_starts = [5., 5 + 1/1.1, 7 + .9/(2/1.5), 7 + 1.9/(2/1.5), 8.5 + .5,
-                   8.5 + 1.5]
-    note_ends = [5 + .5/1.1, 7 + .4/(2/1.5), 7 + 1.4/(2/1.5), 8.5, 9 + .5,
-                 10 + .5]
-    note_pitches = [101, 102, 103, 104, 107, 108, 109]
+    note_starts = [5.0, 5.909090909090909, 7.125, 8.375, 9.0, 10.0]
+    note_ends = [5.454545454545454, 6.5, 7.75, 8.5, 9.5, 10.5]
+    note_pitches = [101, 102, 103, 104, 107, 108]
     for note, s, e, p in zip(pm.instruments[0].notes, note_starts, note_ends,
                              note_pitches):
         assert note.start == s

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -274,7 +274,7 @@ def test_adjust_times():
     ts_times = [first_ts_time, 8.5, 8.5]
     ts_numerators = [3, 4, 6]
     for ts, t, n in zip(pm.time_signature_changes, ts_times, ts_numerators):
-        assert np.allclose(ts.time, t)
+        assert np.isclose(ts.time, t)
         assert ts.numerator == n
 
     ks_times = [5., 8.5, 8.5]

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -213,7 +213,7 @@ def test_adjust_times():
     # Original tempo change times: [0, 6, 8.1, 8.3, 9.3]
     # Plus tempo changes at each of new_times which are not collapsed
     # Plus tempo change at 0s by default
-    expected_times = [0., 5., 6., 8.5,
+    expected_times = [0., 5., 6, 8.5,
                       8.5 + (6 - 5.1)*(11 - 8.5)/(10 - 5.1),
                       8.5 + (8.1 - 5.1)*(11 - 8.5)/(10 - 5.1),
                       8.5 + (8.3 - 5.1)*(11 - 8.5)/(10 - 5.1),
@@ -233,8 +233,18 @@ def test_adjust_times():
     assert np.allclose(expected_tempi, tempi, rtol=.002)
 
     # Test that all other events were interpolated as expected
-    note_starts = [5.0, 5.909090909090909, 7.125, 8.375, 9.0, 10.0]
-    note_ends = [5.454545454545454, 6.5, 7.75, 8.5, 9.5, 10.5]
+    note_starts = [5.0, 
+                   5 + 1/1.1, 
+                   6 + .9/(2/2.5), 
+                   6 + 1.9/(2/2.5), 
+                   8.5 + .5,
+                   8.5 + 1.5]
+    note_ends = [5 + .5/1.1, 
+                 6 + .4/(2/2.5), 
+                 6 + 1.4/(2/2.5), 
+                 8.5, 
+                 8.5 + 1.,
+                 10 + .5]
     note_pitches = [101, 102, 103, 104, 107, 108]
     for note, s, e, p in zip(pm.instruments[0].notes, note_starts, note_ends,
                              note_pitches):
@@ -259,13 +269,13 @@ def test_adjust_times():
     # The first time signature change will be placed at the first interpolated
     # downbeat location - so, start by computing the location of the first
     # downbeat after the start of original_times, then interpolate it
-#    first_downbeat_after = .1 + 2*3*60./100.
-#    first_ts_time = 7 + (first_downbeat_after - 3.1)/(2/1.5)
-#    ts_times = [first_ts_time, 8.5, 8.5]
-#    ts_numerators = [3, 4, 6]
-#    for ts, t, n in zip(pm.time_signature_changes, ts_times, ts_numerators):
-#        assert ts.time == t
-#        assert ts.numerator == n
+    first_downbeat_after = .1 + 2*3*60./100.
+    first_ts_time = 6. + (first_downbeat_after - 3.1)/(2./2.5)
+    ts_times = [first_ts_time, 8.5, 8.5]
+    ts_numerators = [3, 4, 6]
+    for ts, t, n in zip(pm.time_signature_changes, ts_times, ts_numerators):
+        assert np.allclose(ts.time, t)
+        assert ts.numerator == n
 
     ks_times = [5., 8.5, 8.5]
     ks_keys = [1, 2, 3]

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -213,7 +213,7 @@ def test_adjust_times():
     # Original tempo change times: [0, 6, 8.1, 8.3, 9.3]
     # Plus tempo changes at each of new_times which are not collapsed
     # Plus tempo change at 0s by default
-    expected_times = [0., 5., 6, 8.5,
+    expected_times = [0., 5., 6., 8.5,
                       8.5 + (6 - 5.1)*(11 - 8.5)/(10 - 5.1),
                       8.5 + (8.1 - 5.1)*(11 - 8.5)/(10 - 5.1),
                       8.5 + (8.3 - 5.1)*(11 - 8.5)/(10 - 5.1),

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -233,16 +233,16 @@ def test_adjust_times():
     assert np.allclose(expected_tempi, tempi, rtol=.002)
 
     # Test that all other events were interpolated as expected
-    note_starts = [5.0, 
-                   5 + 1/1.1, 
-                   6 + .9/(2/2.5), 
-                   6 + 1.9/(2/2.5), 
+    note_starts = [5.0,
+                   5 + 1/1.1,
+                   6 + .9/(2/2.5),
+                   6 + 1.9/(2/2.5),
                    8.5 + .5,
                    8.5 + 1.5]
-    note_ends = [5 + .5/1.1, 
-                 6 + .4/(2/2.5), 
-                 6 + 1.4/(2/2.5), 
-                 8.5, 
+    note_ends = [5 + .5/1.1,
+                 6 + .4/(2/2.5),
+                 6 + 1.4/(2/2.5),
+                 8.5,
                  8.5 + 1.,
                  10 + .5]
     note_pitches = [101, 102, 103, 104, 107, 108]


### PR DESCRIPTION
Hello, I've attempted to address issue #126 with this commit. There's a private method _strictly_increasing() that takes a 1d array as input. If the values in the array strictly increase with index, then nothing happens. Otherwise, the function returns the result of running np.maximum.accumulate on the input. 