### PR TITLE
Add a method for merging subsequent notes

### DIFF
--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -1242,6 +1242,14 @@ class PrettyMIDI(object):
         for instrument in self.instruments:
             instrument.remove_invalid_notes()
 
+    def merge_subsequent_notes(self):
+        """Merges all notes which are directly following each
+        other and have the same pitch, velocity is averaged.
+        """
+        # Simply call the child method on all instruments
+        for instrument in self.instruments:
+            instrument.merge_subsequent_notes()
+
     def write(self, filename):
         """Write the MIDI data out to a .mid file.
 


### PR DESCRIPTION
This pull request adds a method in the Instrument class for merging subsequent notes in an instrument and a method in the PrettyMIDI object to call this method on all its instruments. All notes that directly follow each other and have the same pitch are merged to one note with a velocity that is the average of all merged notes.

When doing any kind of frame wise pitch predictions I found this method useful to listen to the outcome in a more 'continuos' way than a frame wise cluttered mess... I don't know if this is in general a valuable feature for pretty-midi to have, but I propose it here so you can decide yourself!