### PR TITLE
Fix integrated piano roll division by zero

### DIFF
--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -188,9 +188,12 @@ class Instrument(object):
         # Convert to column indices
         times = np.array(np.round(times*fs), dtype=np.int)
         for n, (start, end) in enumerate(zip(times[:-1], times[1:])):
-            # Each column is the mean of the columns in piano_roll
-            piano_roll_integrated[:, n] = np.mean(piano_roll[:, start:end],
-                                                  axis=1)
+            if start < piano_roll.shape[1]:  # if start is >=, leave zeros
+                if start == end:
+                    end = start + 1
+                # Each column is the mean of the columns in piano_roll
+                piano_roll_integrated[:, n] = np.mean(piano_roll[:, start:end],
+                                                      axis=1)
         return piano_roll_integrated
 
     def get_chroma(self, fs=100, times=None, pedal_threshold=64):
@@ -368,7 +371,7 @@ class Instrument(object):
             raise ValueError('wave should be a callable Python function')
         # This is a simple way to make the end of the notes fade-out without
         # clicks
-        fade_out = np.linspace(1, 0, .1*fs)
+        fade_out = np.linspace(1, 0, int(.1*fs))
         # Create a frequency multiplier array for pitch bend
         bend_multiplier = np.ones(synthesized.shape)
         # Need to sort the pitch bend list for the loop below to work

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -478,6 +478,22 @@ def test_get_piano_roll_and_get_chroma():
                        expected_chroma)
 
 
+def test_get_piano_roll_integrated():
+    pm = pretty_midi.PrettyMIDI()
+    inst = pretty_midi.Instrument(0)
+    pm.instruments.append(inst)
+    inst.notes.append(pretty_midi.Note(pitch=70, velocity=90, start=0.01,
+                                       end=0.05))
+    times = np.linspace(0., 0.06, num=12, endpoint=False)  # sampling at 200
+    # piano roll samples at 100, needs to interpolate to 200
+    piano_roll = pm.instruments[0].get_piano_roll(fs=100, times=times)
+    expected_piano_roll = np.zeros((128, 12))
+    expected_piano_roll[70, 2:10] = 90.
+    print(expected_piano_roll[70])
+    print(piano_roll[70])
+    assert np.allclose(piano_roll, expected_piano_roll)
+
+
 def test_synthesize():
     pm = pretty_midi.PrettyMIDI()
     assert pm.synthesize().size == 0

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -489,8 +489,6 @@ def test_get_piano_roll_integrated():
     piano_roll = pm.instruments[0].get_piano_roll(fs=100, times=times)
     expected_piano_roll = np.zeros((128, 12))
     expected_piano_roll[70, 2:10] = 90.
-    print(expected_piano_roll[70])
-    print(piano_roll[70])
     assert np.allclose(piano_roll, expected_piano_roll)
 
 


### PR DESCRIPTION
When supplying a time array to piano roll, if the time array
exceeds the length of the "native" piano roll generated based
on when the last note finishes, the mean of empty arrays is
computed, resulting in warnings and populating the outputted
piano roll with 'nan'. Similarly, if the time array has a greater
sampling rate than the "native" piano roll, more empty arrays
are generated, resulting in 'nan's when numpy.mean is computed.

- Fixed the above issues as long as time array is increasing
  and greater than or equal to 0.
- Added unit test for the fix
- Made casting to integer explicit in instrument.py to stop
  the numpy deprecation warning