### PR TITLE
add some condition for recognize drum track

### DIFF
--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -323,10 +323,20 @@ class PrettyMIDI(object):
                         end_tick = event.time
                         open_notes = last_note_on[key]
 
-                        notes_to_close = [
-                            (start_tick, velocity)
-                            for start_tick, velocity in open_notes
-                            if start_tick != end_tick]
+                        if event.channel != 9:
+                            notes_to_close = [
+                                (start_tick, velocity)
+                                for start_tick, velocity in open_notes
+                                if start_tick != end_tick]
+                        else:
+                            notes_to_close = []
+                            for start_tick, velocity in open_notes:
+                                if start_tick == end_tick:
+                                    notes_to_close.append((start_tick, velocity))
+                                    end_tick += 5
+                                else:
+                                    notes_to_close.append((start_tick, velocity))
+                                    
                         notes_to_keep = [
                             (start_tick, velocity)
                             for start_tick, velocity in open_notes


### PR DESCRIPTION
For some drum tracks, the **Note** duration is very short. So it's the start time and end time could be in a tick, which may cause can't recognize the track successful. So I add the condition for recognizing the drum better.  