### PR TITLE
Added vocals instrument recognition and extended lyrics for text events

### DIFF
--- a/pretty_midi/containers.py
+++ b/pretty_midi/containers.py
@@ -179,7 +179,7 @@ class KeySignature(object):
 
 
 class Lyric(object):
-    """Timestamped lyric text.
+    """Timestamped lyric text with corresponding note.
 
     Attributes
     ----------
@@ -187,15 +187,21 @@ class Lyric(object):
         The text of the lyric.
     time : float
         The time in seconds of the lyric.
+    note: :class:`pretty_midi.Note` object
+        The note that corresponds to lyric, None for empty text.
     """
 
     def __init__(self, text, time):
         self.text = text
         self.time = time
+        self.note = None
+
+    def set_note(self, note):
+        self.note = note
 
     def __repr__(self):
-        return 'Lyric(text="{}", time={})'.format(
-            self.text.replace('"', r'\"'), self.time)
+        return 'Lyric(text="{}", time={}, note={})'.format(
+            self.text.replace('"', r'\"'), self.time, self.note)
 
     def __str__(self):
-        return '"{}" at {:.2f} seconds'.format(self.text, self.time)
+        return '"{}" at {:.2f} seconds, {}'.format(self.text, self.time, self.note)

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -34,6 +34,8 @@ class Instrument(object):
         The program number of this instrument.
     is_drum : bool
         Is the instrument a drum instrument (channel 9)?
+    is_vocals : bool
+        Is the 'instrument' a vocalist, synchronized with the lyrics
     name : str
         Name of the instrument.
     notes : list
@@ -51,10 +53,14 @@ class Instrument(object):
         """
         self.program = program
         self.is_drum = is_drum
+        self.is_vocals = False
         self.name = name
         self.notes = []
         self.pitch_bends = []
         self.control_changes = []
+
+    def set_as_vocals(self):
+        self.is_vocals = True
 
     def get_onsets(self):
         """Get all onsets of all notes played by this instrument.
@@ -530,5 +536,5 @@ class Instrument(object):
         return synthesized
 
     def __repr__(self):
-        return 'Instrument(program={}, is_drum={}, name="{}")'.format(
-            self.program, self.is_drum, self.name.replace('"', r'\"'))
+        return 'Instrument(program={}, is_drum={}, is_vocals={}, name="{}")'.format(
+            self.program, self.is_drum, self.is_vocals, self.name.replace('"', r'\"'))


### PR DESCRIPTION
By counting maximum number of instrument's note-ons and lyrics events coincidences, the instrument that corresponds to vocals is marked with is_vocals. Also, each lyrics object contains the corresponding note, if exists (not whitespace). Finally, load_metadata takes into account all tracks and lyrics are also created for text events (not only lyrics events).