### PR TITLE
Fix get_piano_roll pedal implementation  

### DIFF
--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -118,7 +118,7 @@ class Instrument(object):
         for note in self.notes:
             # Should interpolate
             piano_roll[note.pitch,
-                       int(note.start*fs):int(note.end*fs)] += note.velocity
+                       int(note.start*fs):int(note.end*fs)+1] += note.velocity
 
         # Process sustain pedals
         if pedal_threshold is not None:
@@ -129,7 +129,7 @@ class Instrument(object):
             # Keep track of non-quantized offset times
             end_times = np.zeros((128, int(fs * end_time)))
             for note in self.notes:
-                end_times[note.pitch, int(note.start*fs):int(note.end*fs)] = note.end
+                end_times[note.pitch, int(note.start*fs):int(note.end*fs)+1] = note.end
                 
             for cc in [_e for _e in self.control_changes
                        if _e.number == CC_SUSTAIN_PEDAL]:
@@ -149,11 +149,11 @@ class Instrument(object):
                     # exact timing into account
                     held_notes = end_times[:, time_pedal_on] >= time_pedal_on_exact
                     piano_roll[:, time_pedal_on] *= held_notes
-                    subpr = piano_roll[:, time_pedal_on:time_now]
+                    subpr = piano_roll[:, time_pedal_on:time_now+1]
 
                     # Take the running maximum
                     pedaled = np.maximum.accumulate(subpr, axis=1)
-                    piano_roll[:, time_pedal_on:time_now] = pedaled
+                    piano_roll[:, time_pedal_on:time_now+1] = pedaled
                     is_pedal_on = False
 
         # Process pitch changes


### PR DESCRIPTION
I'm not entirely sure whether I precisely understand the desired output of get_piano_roll. 
However, after comparing it with https://github.com/magenta/note-seq/tree/master and the piano-roll from there I think there are two small issues with it:
One is an off-by-one error and the other happens when a note offset happens just before/after the pedal is pressed down:

Due to rounding, the pedal might be pressed after the note offset has already occurred.
For example, both offset a and offset b round to t0, and would be held:
t0-->t0+fs
|      *     |  pedal
| *          | offset a -> should not be held
|          * | offset b -> should be held

Again I'm not sure whether the spec of get_piano_roll is different from other piano rolls. 
I think regardless of that, the pedal issue should be addressed.
 