### PR TITLE
np.int is deprecated in numpy>=1.20 - use np.int32 instead

### DIFF
--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -186,7 +186,7 @@ class Instrument(object):
             return piano_roll
         piano_roll_integrated = np.zeros((128, times.shape[0]))
         # Convert to column indices
-        times = np.array(np.round(times*fs), dtype=np.int)
+        times = np.array(np.round(times*fs), dtype=np.int32)
         for n, (start, end) in enumerate(zip(times[:-1], times[1:])):
             if start < piano_roll.shape[1]:  # if start is >=, leave zeros
                 if start == end:

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -321,7 +321,7 @@ class PrettyMIDI(object):
             last_note_on = collections.defaultdict(list)
             # Keep track of which instrument is playing in each channel
             # initialize to program 0 for all channels
-            current_instrument = np.zeros(16, dtype=np.int)
+            current_instrument = np.zeros(16, dtype=np.int32)
             for event in track:
                 # Look for track name events
                 if event.type == 'track_name':


### PR DESCRIPTION
Fix in response to the warnings that I currently get when using `pretty_midi==0.2.9` and `numpy>=1.20`, here's the original warning message:

```
lib/python3.9/site-packages/pretty_midi/pretty_midi.py:295: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    current_instrument = np.zeros(16, dtype=np.int)
```