### PR TITLE
one-line data preparation for mir_eval

### DIFF
--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -17,7 +17,7 @@ from heapq import merge
 from .instrument import Instrument
 from .containers import (KeySignature, TimeSignature, Lyric, Note,
                          PitchBend, ControlChange, Text)
-from .utilities import (key_name_to_key_number, qpm_to_bpm)
+from .utilities import (key_name_to_key_number, qpm_to_bpm, note_number_to_hz)
 
 # The largest we'd ever expect a tick to be
 MAX_TICK = 1e7
@@ -822,6 +822,13 @@ class PrettyMIDI(object):
         for roll in piano_rolls:
             piano_roll[:, :roll.shape[1]] += roll
         return piano_roll
+
+    def get_intervals_and_pitches(self):
+        notes = [n for i in self.instruments for n in i.notes]
+        notes = sorted(notes, key=lambda n: n.start)
+        intervals = np.array([[n.start, n.end] for n in notes])
+        pitches = np.array([note_number_to_hz(n.pitch) for n in notes])
+        return intervals, pitches
 
     def get_pitch_class_histogram(self, use_duration=False,
                                   use_velocity=False, normalize=True):

--- a/tests/test_pretty_midi.py
+++ b/tests/test_pretty_midi.py
@@ -510,3 +510,26 @@ def test_synthesize():
     # Should be normalied
     assert (np.allclose(synthesized.max(), 1) or
             np.allclose(synthesized.min(), -1))
+
+
+def test_get_intervals_and_pitches():
+    pm = pretty_midi.PrettyMIDI()
+    inst = pretty_midi.Instrument(0)
+    pm.instruments.append(inst)
+
+    inst.notes.append(pretty_midi.Note(pitch=69, velocity=90, start=0.01,
+                                       end=0.5))
+    inst.notes.append(pretty_midi.Note(pitch=57, velocity=90, start=0.51,
+                                       end=1.0))
+    inst.notes.append(pretty_midi.Note(pitch=45, velocity=90, start=1.01,
+                                       end=1.5))
+    inst.notes.append(pretty_midi.Note(pitch=33, velocity=90, start=1.51,
+                                       end=2.0))
+
+    expected_intervals = np.array([[0.01, 0.5], [0.51, 1.0], [1.01, 1.5], [1.51, 2.0]])
+    expected_pitches = np.array([440, 220, 110, 55])
+
+    intervals, pitches = pm.get_intervals_and_pitches()
+
+    assert np.allclose(intervals, expected_intervals)
+    assert np.allclose(pitches, expected_pitches)


### PR DESCRIPTION
Hi @craffel , I use `pretty_midi`, `mir_eval`, and `mido` almost every day in my research. Thank you so much!

This feature feels like it should exist in the field of MIR: 

- I have two MIDI files (ground truth and inference)
- I want the transcription metrics **now**

At first I thought, "I should open a PR in `mir_eval` for this", but I realized it would introduce a dependency or a custom rolled MIDI parser :-1: ... _but_ it would be slick if `pretty_midi` could prepare the inputs for `mir_eval.transcription` (especially considering the projects have the same author... 😇 )

With this change you can do:
```
import pretty_midi as pm
import mir_eval

ref_intervals, ref_pitches = pm.PrettyMidi("ground_truth.mid").get_intervals_and_pitches()
est_intervals, est_pitches = pm.PrettyMidi("inference.mid").get_intervals_and_pitches()

(p, r, f, _) = mir_eval.transcription.precision_recall_f1_overlap(
         ref_intervals, ref_pitches,
         est_intervals, est_pitches, 
         offset_ratio=None)
```

and I think that's pretty cool.