### PR TITLE
Allow reusing the Fluidsynth instance for synthesis

### DIFF
--- a/pretty_midi/fluidsynth.py
+++ b/pretty_midi/fluidsynth.py
@@ -1,0 +1,64 @@
+"""Utility functions for handling fluidsynth
+
+"""
+
+import os
+import pkg_resources
+
+try:
+    import fluidsynth
+    _HAS_FLUIDSYNTH = True
+except ImportError:
+    _HAS_FLUIDSYNTH = False
+
+DEFAULT_SF2 = 'TimGM6mb.sf2'
+
+
+def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=44100):
+    """ Check if a valid fluidsynth.Synth instance is provided, and if not,
+    create one.
+
+    Parameters
+    ----------
+    synthesizer : fluidsynth.Synth or str
+        fluidsynth.Synth instance to use or a string with the path to a .sf2 file.
+        Default ``None``, which creates a new instance using the TimGM6mb.sf2 file
+        included with ``pretty_midi``.
+    sfid : int
+        Soundfont ID to use if an instance of fluidsynth.Synth is provided.
+        Default ``0``, which uses the first soundfont.
+    fs : int
+        Sampling rate to synthesize at.
+        Only used when a new instance of fluidsynth.Synth is created.
+        Default ``44100``.
+
+    Returns
+    -------
+    synthesizer : fluidsynth.Synth
+        fluidsynth.Synth instance
+    sfid : int
+        Soundfont ID
+    new_instance_created : bool
+        Whether a new instance of fluidsynth.Synth was created.
+
+    """
+    if not _HAS_FLUIDSYNTH:
+        raise ImportError("fluidsynth() was called but pyfluidsynth is not installed.")
+
+    if synthesizer is None:
+        synthesizer = pkg_resources.resource_filename(__name__, DEFAULT_SF2)
+
+    # Create a fluidsynth instance if one wasn't provided
+    if isinstance(synthesizer, str):
+        sf2_path = synthesizer
+        if not os.path.exists(synthesizer):
+            raise ValueError("No soundfont file found at the supplied path {}".format(sf2_path))
+        synthesizer = fluidsynth.Synth(samplerate=fs)
+        sfid = synthesizer.sfload(sf2_path)
+        new_instance_created = True
+    elif isinstance(synthesizer, fluidsynth.Synth):
+        new_instance_created = False
+    else:
+        raise ValueError("synthesizer must be a str or a fluidsynth.Synth instance")
+
+    return synthesizer, sfid, new_instance_created

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -431,11 +431,15 @@ class Instrument(object):
 
         return synthesized
 
-    def fluidsynth(self, synthesizer=None, sfid=0, fs=44100, sf2_path=None):
+    def fluidsynth(self, fs=44100, synthesizer=None, sfid=0, sf2_path=None):
         """Synthesize using fluidsynth.
 
         Parameters
         ----------
+        fs : int
+            Sampling rate to synthesize at.
+            Only used when a new instance of fluidsynth.Synth is created.
+            Default ``44100``.
         synthesizer : fluidsynth.Synth or str
             fluidsynth.Synth instance to use or a string with the path to a .sf2 file.
             Default ``None``, which creates a new instance using the TimGM6mb.sf2 file
@@ -443,10 +447,6 @@ class Instrument(object):
         sfid : int
             Soundfont ID to use if an instance of fluidsynth.Synth is provided.
             Default ``0``, which uses the first soundfont.
-        fs : int
-            Sampling rate to synthesize at.
-            Only used when a new instance of fluidsynth.Synth is created.
-            Default ``44100``.
         sf2_path : str
             Path to a .sf2 file.
             Default ``None``, which uses the TimGM6mb.sf2 file included with

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -541,7 +541,7 @@ class Instrument(object):
             # Add in these samples
             current_sample = int(fs*current_time)
             end = int(fs*(current_time + event[0]))
-            samples = fl.get_samples(end - current_sample)[::2]
+            samples = synthesizer.get_samples(end - current_sample)[::2]
             synthesized[current_sample:end] += samples
             # Increment the current sample
             current_time += event[0]

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -1,6 +1,7 @@
 """The Instrument class holds all events for a single instrument and contains
 functions for extracting information from the events it contains.
 """
+from warnings import warn
 import numpy as np
 try:
     import fluidsynth
@@ -430,23 +431,28 @@ class Instrument(object):
 
         return synthesized
 
-    def fluidsynth(self, fs=44100, sf2_path=None, fl=None, sfid=0):
+    def fluidsynth(self, synthesizer=None, sfid=0, fs=44100, sf2_path=None):
         """Synthesize using fluidsynth.
 
         Parameters
         ----------
+        synthesizer : fluidsynth.Synth or str
+            fluidsynth.Synth instance to use or a string with the path to a .sf2 file.
+            Default ``None``, which creates a new instance using the TimGM6mb.sf2 file
+            included with ``pretty_midi``.
+        sfid : int
+            Soundfont ID to use if an instance of fluidsynth.Synth is provided.
+            Default ``0``, which uses the first soundfont.
         fs : int
-            Sampling rate to synthesize.
+            Sampling rate to synthesize at.
+            Only used when a new instance of fluidsynth.Synth is created.
+            Default ``44100``.
         sf2_path : str
             Path to a .sf2 file.
             Default ``None``, which uses the TimGM6mb.sf2 file included with
             ``pretty_midi``.
-        fl : fluidsynth.Synth
-            Fluidsynth instance to use. Default ``None``, which creates a new instance
-            using ``sf2_path``.
-        sfid : int
-            Soundfont ID to use if fl is provided. Default ``0``, which usues
-            the first soundfont.
+            .. deprecated:: 0.2.11
+                Use :param:`synthesizer` instead.
 
         Returns
         -------
@@ -454,49 +460,48 @@ class Instrument(object):
             Waveform of the MIDI data, synthesized at ``fs``.
 
         """
+        if not _HAS_FLUIDSYNTH:
+            raise ImportError("fluidsynth() was called but pyfluidsynth is not installed.")
+
+        if sf2_path is not None:
+            warn("The parameter 'sf2_path' is deprecated, please use 'synthesizer' instead.",
+                 DeprecationWarning, 2)
+            if synthesizer is not None:
+                raise ValueError("sf2_path and synthesizer cannot both be supplied.")
+            else:
+                synthesizer = sf2_path
+
+        if synthesizer is None:
+            synthesizer = pkg_resources.resource_filename(__name__, DEFAULT_SF2)
+
         # If the instrument has no notes, return an empty array
         if len(self.notes) == 0:
             return np.array([])
 
-        if sf2_path is not None and fl is not None:
-            raise ValueError("sf2_path and fl cannot both be supplied.")
-        if fl is None and sfid != 0:
-            raise ValueError("sfid cannot be supplied without an fl.")
-
-        if fl is None:
-            # If sf2_path and fl is None, use the included TimGM6mb.sf2 path
-            if sf2_path is None:
-                sf2_path = pkg_resources.resource_filename(__name__, DEFAULT_SF2)
-
-            if not _HAS_FLUIDSYNTH:
-                raise ImportError("fluidsynth() was called but pyfluidsynth "
-                                  "is not installed.")
-
-            if not os.path.exists(sf2_path):
-                raise ValueError("No soundfont file found at the supplied path "
-                                 "{}".format(sf2_path))
-
-            # Create fluidsynth instance
-            fl = fluidsynth.Synth(samplerate=fs)
-            delete_fl = True
-            # Load in the soundfont
-            sfid = fl.sfload(sf2_path)
+        # Create a fluidsynth instance if one wasn't provided
+        if type(synthesizer) is str:
+            sf2_path = synthesizer
+            if not os.path.exists(synthesizer):
+                raise ValueError("No soundfont file found at the supplied path {}".format(sf2_path))
+            synthesizer = fluidsynth.Synth(samplerate=fs)
+            delete_synthesizer = True
+            sfid = synthesizer.sfload(sf2_path)
         else:
-            delete_fl = False
+            delete_synthesizer = False
 
         # If this is a drum instrument, use channel 9 and bank 128
         if self.is_drum:
             channel = 9
             # Try to use the supplied program number
-            res = fl.program_select(channel, sfid, 128, self.program)
+            res = synthesizer.program_select(channel, sfid, 128, self.program)
             # If the result is -1, there's no preset with this program number
             if res == -1:
                 # So use preset 0
-                fl.program_select(channel, sfid, 128, 0)
+                synthesizer.program_select(channel, sfid, 128, 0)
         # Otherwise just use channel 0
         else:
             channel = 0
-            fl.program_select(channel, sfid, 0, self.program)
+            synthesizer.program_select(channel, sfid, 0, self.program)
         # Collect all notes in one list
         event_list = []
         for note in self.notes:
@@ -526,13 +531,13 @@ class Instrument(object):
         for event in event_list:
             # Process events based on type
             if event[1] == 'note on':
-                fl.noteon(channel, event[2], event[3])
+                synthesizer.noteon(channel, event[2], event[3])
             elif event[1] == 'note off':
-                fl.noteoff(channel, event[2])
+                synthesizer.noteoff(channel, event[2])
             elif event[1] == 'pitch bend':
-                fl.pitch_bend(channel, event[2])
+                synthesizer.pitch_bend(channel, event[2])
             elif event[1] == 'control change':
-                fl.cc(channel, event[2], event[3])
+                synthesizer.cc(channel, event[2], event[3])
             # Add in these samples
             current_sample = int(fs*current_time)
             end = int(fs*(current_time + event[0]))
@@ -541,8 +546,8 @@ class Instrument(object):
             # Increment the current sample
             current_time += event[0]
         # Close fluidsynth if it was a local instance created in the function
-        if delete_fl:
-            fl.delete()
+        if delete_synthesizer:
+            synthesizer.delete()
 
         return synthesized
 

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -479,15 +479,17 @@ class Instrument(object):
             return np.array([])
 
         # Create a fluidsynth instance if one wasn't provided
-        if type(synthesizer) is str:
+        if isinstance(synthesizer, str):
             sf2_path = synthesizer
             if not os.path.exists(synthesizer):
                 raise ValueError("No soundfont file found at the supplied path {}".format(sf2_path))
             synthesizer = fluidsynth.Synth(samplerate=fs)
             delete_synthesizer = True
             sfid = synthesizer.sfload(sf2_path)
-        else:
+        elif isinstance(synthesizer, fluidsynth.Synth):
             delete_synthesizer = False
+        else:
+            raise ValueError("synthesizer must be a str or a fluidsynth.Synth instance")
 
         # If this is a drum instrument, use channel 9 and bank 128
         if self.is_drum:

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -1016,15 +1016,17 @@ class PrettyMIDI(object):
             return np.array([])
 
         # Create a fluidsynth instance if one wasn't provided
-        if type(synthesizer) is str:
+        if isinstance(synthesizer, str):
             sf2_path = synthesizer
             if not os.path.exists(synthesizer):
                 raise ValueError("No soundfont file found at the supplied path {}".format(sf2_path))
             synthesizer = fluidsynth.Synth(samplerate=fs)
             delete_synthesizer = True
             sfid = synthesizer.sfload(sf2_path)
-        else:
+        elif isinstance(synthesizer, fluidsynth.Synth):
             delete_synthesizer = False
+        else:
+            raise ValueError("synthesizer must be a str or a fluidsynth.Synth instance")
 
         # Get synthesized waveform for each instrument
         waveforms = [i.fluidsynth(synthesizer=synthesizer, sfid=sfid) for i in self.instruments]

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -966,11 +966,15 @@ class PrettyMIDI(object):
         synthesized /= np.abs(synthesized).max()
         return synthesized
 
-    def fluidsynth(self, synthesizer=None, sfid=0, fs=44100, sf2_path=None):
+    def fluidsynth(self, fs=44100, synthesizer=None, sfid=0, sf2_path=None):
         """Synthesize using fluidsynth.
 
         Parameters
         ----------
+        fs : int
+            Sampling rate to synthesize at.
+            Only used when a new instance of fluidsynth.Synth is created.
+            Default ``44100``.
         synthesizer : fluidsynth.Synth or str
             fluidsynth.Synth instance to use or a string with the path to a .sf2 file.
             Default ``None``, which creates a new instance using the TimGM6mb.sf2 file
@@ -978,10 +982,6 @@ class PrettyMIDI(object):
         sfid : int
             Soundfont ID to use if an instance of fluidsynth.Synth is provided.
             Default ``0``, which uses the first soundfont.
-        fs : int
-            Sampling rate to synthesize at.
-            Only used when a new instance of fluidsynth.Synth is created.
-            Default ``44100``.
         sf2_path : str
             Path to a .sf2 file.
             Default ``None``, which uses the TimGM6mb.sf2 file included with

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -1027,7 +1027,7 @@ class PrettyMIDI(object):
             delete_synthesizer = False
 
         # Get synthesized waveform for each instrument
-        waveforms = [i.fluidsynth(fl=synthesizer, sfid=sfid) for i in self.instruments]
+        waveforms = [i.fluidsynth(synthesizer=synthesizer, sfid=sfid) for i in self.instruments]
 
         # Close fluidsynth if it was a local instance created in the function
         if delete_synthesizer:


### PR DESCRIPTION
Hello,

This PR modifies the `fluidsynth` method of the class `Instrument` to allow providing an existing Fluidsynth instance with the sf2 file already loaded instead of providing the path to the sf2 file and creating a new Fluidsynth instance inside the method. The `fluidsynth` method of the class `PrettyMIDI` is modified in a similar way and also to take advantage of the modifications in `Instrument.fluidsynth` so the same Fluidsynth instance is used to synthesize all the instruments in the song.

These changes really reduce the synthesis time of MIDI objects with many instruments without the users needing to modify their code and allow them to speed up their code even more if they need to synthesize many different MIDI objects by creating their own Fluidsynth instance by themselves and reusing it for all the objects. 

Best,
David