### PR TITLE
Pass sample rate to Instrument.fluidsynth

### DIFF
--- a/pretty_midi/fluidsynth.py
+++ b/pretty_midi/fluidsynth.py
@@ -31,7 +31,7 @@ def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=None):
     fs : int
         Sampling rate to synthesize at.
         Default ``None``, which falls back to ``pretty_midi.fluidsynth.DEFAULT_SAMPLE_RATE``
-        if a new instance must be created.
+        = 44100 if a new instance must be created.
         If ``synthesizer`` is an existing instance and ``fs`` is specified, then
         ValueError will be raised if the sample rates are not equal.
 

--- a/pretty_midi/fluidsynth.py
+++ b/pretty_midi/fluidsynth.py
@@ -57,6 +57,10 @@ def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=44100):
         sfid = synthesizer.sfload(sf2_path)
         new_instance_created = True
     elif isinstance(synthesizer, fluidsynth.Synth):
+        if fs:
+            synth_fs = synthesizer.get_setting('synth.sample-rate')
+            if synth_fs != fs:
+                raise ValueError("synth sample-rate does not match fs", synth_fs)
         new_instance_created = False
     else:
         raise ValueError("synthesizer must be a str or a fluidsynth.Synth instance")

--- a/pretty_midi/fluidsynth.py
+++ b/pretty_midi/fluidsynth.py
@@ -12,9 +12,10 @@ except ImportError:
     _HAS_FLUIDSYNTH = False
 
 DEFAULT_SF2 = 'TimGM6mb.sf2'
+DEFAULT_SAMPLE_RATE = 44100
 
 
-def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=44100):
+def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=None):
     """ Check if a valid fluidsynth.Synth instance is provided, and if not,
     create one.
 
@@ -29,8 +30,9 @@ def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=44100):
         Default ``0``, which uses the first soundfont.
     fs : int
         Sampling rate to synthesize at.
-        Only used when a new instance of fluidsynth.Synth is created.
-        Default ``44100``.
+        Default ``None``, which falls back to 44100 if a new instance must be created.
+        If ``synthesizer`` is an existing instance and ``fs`` is specified, then
+        a check is performed to ensure that its sample rate is equal to ``fs``.
 
     Returns
     -------
@@ -53,14 +55,14 @@ def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=44100):
         sf2_path = synthesizer
         if not os.path.exists(synthesizer):
             raise ValueError("No soundfont file found at the supplied path {}".format(sf2_path))
+        fs = fs or DEFAULT_SAMPLE_RATE
         synthesizer = fluidsynth.Synth(samplerate=fs)
         sfid = synthesizer.sfload(sf2_path)
         new_instance_created = True
     elif isinstance(synthesizer, fluidsynth.Synth):
-        if fs:
-            synth_fs = synthesizer.get_setting('synth.sample-rate')
-            if synth_fs != fs:
-                raise ValueError("synth sample-rate does not match fs", synth_fs)
+        synth_fs = synthesizer.get_setting('synth.sample-rate')
+        if fs and synth_fs != fs:
+            raise ValueError("synth sample-rate does not match fs", synth_fs)
         new_instance_created = False
     else:
         raise ValueError("synthesizer must be a str or a fluidsynth.Synth instance")

--- a/pretty_midi/fluidsynth.py
+++ b/pretty_midi/fluidsynth.py
@@ -30,9 +30,10 @@ def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=None):
         Default ``0``, which uses the first soundfont.
     fs : int
         Sampling rate to synthesize at.
-        Default ``None``, which falls back to 44100 if a new instance must be created.
+        Default ``None``, which falls back to ``pretty_midi.fluidsynth.DEFAULT_SAMPLE_RATE``
+        if a new instance must be created.
         If ``synthesizer`` is an existing instance and ``fs`` is specified, then
-        a check is performed to ensure that its sample rate is equal to ``fs``.
+        ValueError will be raised if the sample rates are not equal.
 
     Returns
     -------
@@ -62,7 +63,8 @@ def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=None):
     elif isinstance(synthesizer, fluidsynth.Synth):
         synth_fs = synthesizer.get_setting('synth.sample-rate')
         if fs and synth_fs != fs:
-            raise ValueError("synth sample-rate does not match fs", synth_fs)
+            raise ValueError(
+                f"synthesizer sample rate of {synth_fs} doesn't match provided fs of {fs}")
         new_instance_created = False
     else:
         raise ValueError("synthesizer must be a str or a fluidsynth.Synth instance")

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -431,7 +431,8 @@ class Instrument(object):
         fs : int
             Sampling rate to synthesize at.
             Default ``None``, which takes the sampling rate from ``synthesizer``, or
-            uses 44100 if ``synthesizer`` has not been created.
+            uses ``pretty_midi.fluidsynth.DEFAULT_SAMPLE_RATE`` if ``synthesizer``
+            needs to be created.
         synthesizer : fluidsynth.Synth or str
             fluidsynth.Synth instance to use or a string with the path to a .sf2 file.
             Default ``None``, which creates a new instance using the TimGM6mb.sf2 file
@@ -465,10 +466,11 @@ class Instrument(object):
             return np.array([])
 
         # Create a fluidsynth instance if one wasn't provided
-        # Raises if sample rates do not match
+        # Raises ValueError if sample rates do not match
         synthesizer, sfid, delete_synthesizer = get_fluidsynth_instance(synthesizer, sfid, fs)
         # Sample rate required below to compute note positions
-        fs = fs or synthesizer.get_setting('synth.sample-rate')
+        # Take from synthesizer in case fs was not passed explicitly
+        fs = synthesizer.get_setting('synth.sample-rate')
 
         # If this is a drum instrument, use channel 9 and bank 128
         if self.is_drum:

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -431,7 +431,7 @@ class Instrument(object):
         fs : int
             Sampling rate to synthesize at.
             Default ``None``, which takes the sampling rate from ``synthesizer``, or
-            uses ``pretty_midi.fluidsynth.DEFAULT_SAMPLE_RATE`` if ``synthesizer``
+            uses ``pretty_midi.fluidsynth.DEFAULT_SAMPLE_RATE`` = 44100 if a synthesizer
             needs to be created.
         synthesizer : fluidsynth.Synth or str
             fluidsynth.Synth instance to use or a string with the path to a .sf2 file.

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -423,15 +423,15 @@ class Instrument(object):
 
         return synthesized
 
-    def fluidsynth(self, fs=44100, synthesizer=None, sfid=0, sf2_path=None):
+    def fluidsynth(self, fs=None, synthesizer=None, sfid=0, sf2_path=None):
         """Synthesize using fluidsynth.
 
         Parameters
         ----------
         fs : int
             Sampling rate to synthesize at.
-            Only used when a new instance of fluidsynth.Synth is created.
-            Default ``44100``.
+            Default ``None``, which takes the sampling rate from ``synthesizer``, or
+            uses 44100 if ``synthesizer`` has not been created.
         synthesizer : fluidsynth.Synth or str
             fluidsynth.Synth instance to use or a string with the path to a .sf2 file.
             Default ``None``, which creates a new instance using the TimGM6mb.sf2 file
@@ -465,9 +465,10 @@ class Instrument(object):
             return np.array([])
 
         # Create a fluidsynth instance if one wasn't provided
+        # Raises if sample rates do not match
         synthesizer, sfid, delete_synthesizer = get_fluidsynth_instance(synthesizer, sfid, fs)
-        if not fs:
-            fs = synthesizer.get_setting('synth.sample-rate')
+        # Sample rate required below to compute note positions
+        fs = fs or synthesizer.get_setting('synth.sample-rate')
 
         # If this is a drum instrument, use channel 9 and bank 128
         if self.is_drum:

--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -466,6 +466,8 @@ class Instrument(object):
 
         # Create a fluidsynth instance if one wasn't provided
         synthesizer, sfid, delete_synthesizer = get_fluidsynth_instance(synthesizer, sfid, fs)
+        if not fs:
+            fs = synthesizer.get_setting('synth.sample-rate')
 
         # If this is a drum instrument, use channel 9 and bank 128
         if self.is_drum:

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -1008,7 +1008,8 @@ class PrettyMIDI(object):
         synthesizer, sfid, delete_synthesizer = get_fluidsynth_instance(synthesizer, sfid, fs)
 
         # Get synthesized waveform for each instrument
-        waveforms = [i.fluidsynth(fs=fs, synthesizer=synthesizer, sfid=sfid) for i in self.instruments]
+        waveforms = [i.fluidsynth(fs=fs, synthesizer=synthesizer, sfid=sfid)
+                     for i in self.instruments]
 
         # Close fluidsynth if it was a local instance created in the function
         if delete_synthesizer:

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -1008,7 +1008,7 @@ class PrettyMIDI(object):
         synthesizer, sfid, delete_synthesizer = get_fluidsynth_instance(synthesizer, sfid, fs)
 
         # Get synthesized waveform for each instrument
-        waveforms = [i.fluidsynth(synthesizer=synthesizer, sfid=sfid) for i in self.instruments]
+        waveforms = [i.fluidsynth(fs=fs, synthesizer=synthesizer, sfid=sfid) for i in self.instruments]
 
         # Close fluidsynth if it was a local instance created in the function
         if delete_synthesizer:

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -968,7 +968,8 @@ class PrettyMIDI(object):
         fs : int
             Sampling rate to synthesize at.
             Default ``None``, which takes the sampling rate from ``synthesizer``, or
-            uses 44100 if ``synthesizer`` has not been created.
+            uses ``pretty_midi.fluidsynth.DEFAULT_SAMPLE_RATE`` if ``synthesizer``
+            needs to be created.
         synthesizer : fluidsynth.Synth or str
             fluidsynth.Synth instance to use or a string with the path to a .sf2 file.
             Default ``None``, which creates a new instance using the TimGM6mb.sf2 file

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -968,7 +968,7 @@ class PrettyMIDI(object):
         fs : int
             Sampling rate to synthesize at.
             Default ``None``, which takes the sampling rate from ``synthesizer``, or
-            uses ``pretty_midi.fluidsynth.DEFAULT_SAMPLE_RATE`` if ``synthesizer``
+            uses ``pretty_midi.fluidsynth.DEFAULT_SAMPLE_RATE`` = 44100 if a synthesizer
             needs to be created.
         synthesizer : fluidsynth.Synth or str
             fluidsynth.Synth instance to use or a string with the path to a .sf2 file.

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -960,15 +960,15 @@ class PrettyMIDI(object):
         synthesized /= np.abs(synthesized).max()
         return synthesized
 
-    def fluidsynth(self, fs=44100, synthesizer=None, sfid=0, sf2_path=None):
+    def fluidsynth(self, fs=None, synthesizer=None, sfid=0, sf2_path=None):
         """Synthesize using fluidsynth.
 
         Parameters
         ----------
         fs : int
             Sampling rate to synthesize at.
-            Only used when a new instance of fluidsynth.Synth is created.
-            Default ``44100``.
+            Default ``None``, which takes the sampling rate from ``synthesizer``, or
+            uses 44100 if ``synthesizer`` has not been created.
         synthesizer : fluidsynth.Synth or str
             fluidsynth.Synth instance to use or a string with the path to a .sf2 file.
             Default ``None``, which creates a new instance using the TimGM6mb.sf2 file
@@ -1008,7 +1008,7 @@ class PrettyMIDI(object):
         synthesizer, sfid, delete_synthesizer = get_fluidsynth_instance(synthesizer, sfid, fs)
 
         # Get synthesized waveform for each instrument
-        waveforms = [i.fluidsynth(fs=fs, synthesizer=synthesizer, sfid=sfid)
+        waveforms = [i.fluidsynth(synthesizer=synthesizer, sfid=sfid)
                      for i in self.instruments]
 
         # Close fluidsynth if it was a local instance created in the function


### PR DESCRIPTION
The sample-rate `fs` is only passed implicitly with the synthesizer. However, it is used within Instrument.fluidsynth to compute note positions at the given sample rate.