### PR TITLE
fix: Remove `pkg_resources`

### DIFF
--- a/pretty_midi/fluidsynth.py
+++ b/pretty_midi/fluidsynth.py
@@ -3,7 +3,7 @@
 """
 
 import os
-import pkg_resources
+from importlib import resources
 
 try:
     import fluidsynth
@@ -49,7 +49,7 @@ def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=None):
         raise ImportError("fluidsynth() was called but pyfluidsynth is not installed.")
 
     if synthesizer is None:
-        synthesizer = pkg_resources.resource_filename(__name__, DEFAULT_SF2)
+        synthesizer = resources.path(__name__, DEFAULT_SF2)
 
     # Create a fluidsynth instance if one wasn't provided
     if isinstance(synthesizer, str):

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -17,7 +17,6 @@ import pathlib
 from heapq import merge
 
 import os
-import pkg_resources
 
 from .instrument import Instrument
 from .containers import (KeySignature, TimeSignature, Lyric, Note,


### PR DESCRIPTION
`pkg_resources` is depreciated in Python 3.12. This PR replaces it with `importlib.resources`.