### PR TITLE
Python 3.12 compatibility: remove pkg_resources dependency

### DIFF
--- a/pretty_midi/fluidsynth.py
+++ b/pretty_midi/fluidsynth.py
@@ -49,7 +49,7 @@ def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=None):
         raise ImportError("fluidsynth() was called but pyfluidsynth is not installed.")
 
     if synthesizer is None:
-        synthesizer = str(importlib_resources.files(__name__) / DEFAULT_SF2)
+        synthesizer = os.path.join(str(importlib_resources.files(__name__)), DEFAULT_SF2)
 
     # Create a fluidsynth instance if one wasn't provided
     if isinstance(synthesizer, str):

--- a/pretty_midi/fluidsynth.py
+++ b/pretty_midi/fluidsynth.py
@@ -3,7 +3,7 @@
 """
 
 import os
-import pkg_resources
+import importlib_resources
 
 try:
     import fluidsynth
@@ -49,7 +49,7 @@ def get_fluidsynth_instance(synthesizer=None, sfid=0, fs=None):
         raise ImportError("fluidsynth() was called but pyfluidsynth is not installed.")
 
     if synthesizer is None:
-        synthesizer = pkg_resources.resource_filename(__name__, DEFAULT_SF2)
+        synthesizer = str(importlib_resources.files(__name__) / DEFAULT_SF2)
 
     # Create a fluidsynth instance if one wasn't provided
     if isinstance(synthesizer, str):

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -16,9 +16,6 @@ import six
 import pathlib
 from heapq import merge
 
-import os
-import pkg_resources
-
 from .instrument import Instrument
 from .containers import (KeySignature, TimeSignature, Lyric, Note,
                          PitchBend, ControlChange, Text)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'numpy >= 1.7.0',
         'mido >= 1.1.16',
         'six',
+        'importlib_resources',
     ],
     extras_require={
         'fluidsynth': ['pyfluidsynth>=1.3.1',],


### PR DESCRIPTION
`pretty_midi` doesn't work with python 3.12 because of `pkg_resources` deprecation: https://setuptools.pypa.io/en/latest/pkg_resources.html, `import pretty_midi` fails with:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

Replacing `pkg_resources` with `importlib.resources` is not possible (discussed in https://github.com/craffel/pretty-midi/pull/245), because `resources.files` changed in 3.12: https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files – this PR is using `importlib_resources` backport instead: https://pypi.org/project/importlib-resources/.


Code I used to test:

```python
import pretty_midi

midi = pretty_midi.PrettyMIDI("example.mid")
data = midi.fluidsynth()
```

Right now this returns exactly the same array for pythons 3.12 and 3.10.