### PR TITLE
Modified ```np.int32``` to ```int``` to resolve AttributeError thrown by Numpy>=1.20.0

### DIFF
--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -179,7 +179,7 @@ class Instrument(object):
             return piano_roll
         piano_roll_integrated = np.zeros((128, times.shape[0]))
         # Convert to column indices
-        times = np.array(np.round(times*fs), dtype=np.int32)
+        times = np.array(np.round(times*fs), dtype=int)
         for n, (start, end) in enumerate(zip(times[:-1], times[1:])):
             if start < piano_roll.shape[1]:  # if start is >=, leave zeros
                 if start == end:

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -346,7 +346,6 @@ class PrettyMIDI(object):
             last_note_on = collections.defaultdict(list)
             # Keep track of which instrument is playing in each channel
             # initialize to program 0 for all channels
-            # current_instrument = np.zeros(16, dtype=np.int32) # Raises AttributeError in Numpy>= 1.20.0
             current_instrument = np.zeros(16, dtype=int)
             for event in track:
                 # Look for track name events

--- a/pretty_midi/pretty_midi.py
+++ b/pretty_midi/pretty_midi.py
@@ -346,7 +346,8 @@ class PrettyMIDI(object):
             last_note_on = collections.defaultdict(list)
             # Keep track of which instrument is playing in each channel
             # initialize to program 0 for all channels
-            current_instrument = np.zeros(16, dtype=np.int32)
+            # current_instrument = np.zeros(16, dtype=np.int32) # Raises AttributeError in Numpy>= 1.20.0
+            current_instrument = np.zeros(16, dtype=int)
             for event in track:
                 # Look for track name events
                 if event.type == 'track_name':


### PR DESCRIPTION
With Numpy>=1.20.0, the ```np.int32``` like variable aliases have been deprecated in favor of a more pythonic approach as discussed here https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Today when using ```pretty_midi``` in an environment with Numpy 1.26.4, I encountered this error in the ```pretty_midi.py``` file. I have applied this simple fix and have opened this PR for your review.

With best,
@Mechazo11